### PR TITLE
OC-628 adding bootstrap grid classes to category

### DIFF
--- a/catalog/templates/category.list.tpl.html
+++ b/catalog/templates/category.list.tpl.html
@@ -2,8 +2,8 @@
     <h3 ng-if="categorylist.length > 0" class="page-header">
         {{categorylist.length > 1 ? 'Categories' : 'Category'}}
     </h3>
-    <div class="category-list">
-        <div class="category-list-item" ng-repeat="category in categorylist">
+    <div class="category-list row">
+        <div class="category-list-item col-md-3" ng-repeat="category in categorylist">
             <div class="thumbnail" ui-sref="catalog.category({categoryid: category.ID})">
                 <figure ng-if="category.xp.image">
                     <img class="img-responsive" ng-src="{{category.xp.image.URL}}" alt="Category Image">


### PR DESCRIPTION
adding bootstrap grid classes to category to prevent large category images and/or names from breaking the layout