### PR TITLE
Type ahead 392 cr

### DIFF
--- a/categories/categories.js
+++ b/categories/categories.js
@@ -176,7 +176,7 @@ function CategoriesController( $state, $ocMedia, OrderCloud, OrderCloudParameter
     };
 }
 
-function CategoryEditController( $exceptionHandler, $state, OrderCloud, SelectedCategory, toastr ) {
+function CategoryEditController( $exceptionHandler, $state, $q, OrderCloud, SelectedCategory, toastr ) {
     var vm = this,
         categoryID = SelectedCategory.ID;
     vm.categoryName = SelectedCategory.Name;
@@ -193,6 +193,15 @@ function CategoryEditController( $exceptionHandler, $state, OrderCloud, Selected
             });
     };
 
+    vm.typeAhead = function (searchTerm) {
+        var defd = $q.defer();
+        OrderCloud.Categories.List(searchTerm, 1, 100, null, null, null, null, "all")
+            .then(function (data) {
+                defd.resolve(data.Items)
+            });
+        return defd.promise
+    };
+
     vm.Delete = function() {
         OrderCloud.Categories.Delete(SelectedCategory.ID)
             .then(function() {
@@ -205,23 +214,31 @@ function CategoryEditController( $exceptionHandler, $state, OrderCloud, Selected
     }
 }
 
-function CategoryCreateController($exceptionHandler,$state, OrderCloud, toastr) {
+function CategoryCreateController($exceptionHandler, $state, $q, OrderCloud, toastr) {
     var vm = this;
     vm.category = {};
 
-    vm.Submit = function() {
+    vm.Submit = function () {
         if (vm.category.ParentID === '') {
             vm.category.ParentID = null;
         }
         OrderCloud.Categories.Create(vm.category)
-            .then(function() {
-                $state.go('categories', {}, {reload:true});
+            .then(function () {
+                $state.go('categories', {}, {reload: true});
                 toastr.success('Category Created', 'Success');
             })
-            .catch(function(ex) {
+            .catch(function (ex) {
                 $exceptionHandler(ex);
             });
-    }
+    };
+    vm.typeAhead = function (searchTerm) {
+        var defd = $q.defer();
+        OrderCloud.Categories.List(searchTerm, 1, 100, null, null, null, null, "all")
+            .then(function (data) {
+                defd.resolve(data.Items)
+            });
+        return defd.promise
+    };
 }
 
 function CategoryTreeController(Tree, CategoryTreeService) {

--- a/categories/templates/categoryCreate.tpl.html
+++ b/categories/templates/categoryCreate.tpl.html
@@ -26,7 +26,6 @@
                     placeholder="Search"
                     ng-model="categoryCreate.category.ParentID"
                     uib-typeahead="category.ID as category.Name for category in categoryCreate.typeAhead($viewValue)"
-                    typeahead-editable="false"
                     typeahead-template-url="categories/templates/parentIDtypeAhead.tpl.html"
                     typeahead-on-select="catalogSearch.onSelect($item)"
                     typeahead-focus-first="false"

--- a/categories/templates/categoryCreate.tpl.html
+++ b/categories/templates/categoryCreate.tpl.html
@@ -19,7 +19,19 @@
         </div>
         <div class="form-group col-sm-6">
             <label for="categoryParentIDInput">Parent ID</label>
-            <input id="categoryParentIDInput" type="text" class="form-control" pattern="([A-Za-z0-9\-\_]+)" pattern-err-type="ID_Name" ng-model="categoryCreate.category.ParentID"/>
+            <input
+                    id="categoryParentIDInput"
+                    type="text"
+                    class="form-control"
+                    placeholder="Search"
+                    ng-model="categoryCreate.category.ParentID"
+                    uib-typeahead="category.ID as category.Name for category in categoryCreate.typeAhead($viewValue)"
+                    typeahead-editable="false"
+                    typeahead-template-url="categories/templates/parentIDtypeAhead.tpl.html"
+                    typeahead-on-select="catalogSearch.onSelect($item)"
+                    typeahead-focus-first="false"
+                    ng-model-options="{debounce:{'default':300,'blur':0}}"
+            />
         </div>
     </div>
     <div class="row">

--- a/categories/templates/categoryEdit.tpl.html
+++ b/categories/templates/categoryEdit.tpl.html
@@ -19,7 +19,20 @@
         </div>
         <div class="form-group col-sm-6">
             <label for="categoryParentIDInput">Parent ID</label>
-            <input id="categoryParentIDInput" type="text" class="form-control" pattern="([A-Za-z0-9\-\_]+)" pattern-err-type="ID_Name" ng-model="categoryEdit.category.ParentID"/>
+            <!--<input id="categoryParentIDInput" type="text" class="form-control" pattern="([A-Za-z0-9\-\_]+)" pattern-err-type="ID_Name" ng-model="categoryEdit.category.ParentID"/>-->
+            <input
+                    id="categoryParentIDInput"
+                    type="text"
+                    class="form-control"
+                    placeholder="Search"
+                    ng-model="categoryEdit.category.ParentID"
+                    uib-typeahead="category.ID as category.Name for category in categoryEdit.typeAhead($viewValue)"
+                    typeahead-editable="false"
+                    typeahead-template-url="categories/templates/parentIDtypeAhead.tpl.html"
+                    typeahead-on-select="catalogSearch.onSelect($item)"
+                    typeahead-focus-first="false"
+                    ng-model-options="{debounce:{'default':300,'blur':0}}"
+            />
         </div>
     </div>
     <div class="row">

--- a/categories/templates/categoryEdit.tpl.html
+++ b/categories/templates/categoryEdit.tpl.html
@@ -19,7 +19,6 @@
         </div>
         <div class="form-group col-sm-6">
             <label for="categoryParentIDInput">Parent ID</label>
-            <!--<input id="categoryParentIDInput" type="text" class="form-control" pattern="([A-Za-z0-9\-\_]+)" pattern-err-type="ID_Name" ng-model="categoryEdit.category.ParentID"/>-->
             <input
                     id="categoryParentIDInput"
                     type="text"
@@ -27,7 +26,6 @@
                     placeholder="Search"
                     ng-model="categoryEdit.category.ParentID"
                     uib-typeahead="category.ID as category.Name for category in categoryEdit.typeAhead($viewValue)"
-                    typeahead-editable="false"
                     typeahead-template-url="categories/templates/parentIDtypeAhead.tpl.html"
                     typeahead-on-select="catalogSearch.onSelect($item)"
                     typeahead-focus-first="false"

--- a/categories/templates/parentIDtypeAhead.tpl.html
+++ b/categories/templates/parentIDtypeAhead.tpl.html
@@ -1,0 +1,4 @@
+<a>
+    <span ng-bind-html="match.model.ID | uibTypeaheadHighlight:query"></span>
+     (<span ng-bind-html="match.model.Name | uibTypeaheadHighlight:query"></span>)
+</a>


### PR DESCRIPTION
Adding typeahead functionality to ParentID field on create and edit views. Typeahead searches on both name and ID but populates field with ID only when selected. Entering an invalid id should return error on submit but not upon change of focus.